### PR TITLE
Amended requirements.txt with correct entry for current datamaps repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ appdirs==1.4.3
 Click==7.0
 colorama==0.4.1
 colorlog==4.0.2
-datamaps==1.0.0b0
+-e git+https://github.com/hammerheadlemon/datamaps#egg=datamaps
 et-xmlfile==1.0.1
 jdcal==1.4.1
 openpyxl==2.6.2


### PR DESCRIPTION
@banillie - have amended your requirements file so that it properly picks up the current datamaps repository. As I have said, this is likely to change in future - the API functionality will probably move into `bcompiler-engine`, but for now, this should work.