### PR TITLE
Amended requirements.txt to depend on pypi datamaps rather than gitbub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/hammerheadlemon/datamaps#egg=datamaps
+datamaps>=1.0.0
 -e git+https://github.com/banillie/projectlibrary#egg=projectlibrary
 python-docx==0.8.10
 openpyxl==3.0.0


### PR DESCRIPTION
@banillie  - now that datamaps 1.0.0 is on PyPI, this amends the requirements file to use PyPI instead of my github, which will become unstable as I develop new features.